### PR TITLE
Recent Gradle versions prefer 'mainClass' over 'main'

### DIFF
--- a/src/main/groovy/com/impact/gradle/detangler/plugin/DetanglerPlugin.groovy
+++ b/src/main/groovy/com/impact/gradle/detangler/plugin/DetanglerPlugin.groovy
@@ -17,7 +17,7 @@ class DetanglerPlugin implements Plugin<Project> {
         DetanglerPluginExtension spec = project.extensions.create('detangler', DetanglerPluginExtension)
 
         project.tasks.create("detangler", JavaExec) {
-            main 'com.seanshubin.detangler.console.ConsoleApplication'
+            mainClass 'com.seanshubin.detangler.console.ConsoleApplication'
             classpath project.configurations.detanglerConfig
             dependsOn 'compileJava'
             dependsOn 'compileTestJava'


### PR DESCRIPTION
This is for JavaExec tasks. The old property has been deprecated, and will fail with Gradle 9.x.
The new property has been around since version 6.4